### PR TITLE
Add step-by-step leasing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This simple Flask application lets prospective tenants apply for an apartment on
 
 3. Open your browser at `http://localhost:5000` to access the web app.
 
+## Leasing Process
+
+You can walk through a step-by-step leasing workflow starting at `/process`.
+Each step collects information or confirms actions such as scheduling an
+appointment, completing the application, and reviewing the lease.
+
 Submitted applications are stored in `applications.db` (a SQLite database) in the
 project directory. Each entry records the applicant details along with the date
 and time the application was submitted.

--- a/app.py
+++ b/app.py
@@ -1,8 +1,10 @@
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, redirect, url_for, session
 import sqlite3
 from datetime import datetime
+import os
 
 app = Flask(__name__)
+app.secret_key = os.environ.get("SECRET_KEY", "dev")
 
 DB_NAME = 'applications.db'
 
@@ -67,6 +69,46 @@ def apply():
         save_application(data)
         return render_template('thanks.html', name=data['name'])
     return render_template('apply.html')
+
+
+@app.route('/process', methods=['GET', 'POST'])
+def process():
+    """Handle the step-by-step leasing process."""
+    step = int(request.args.get('step', 1))
+    if 'process_data' not in session:
+        session['process_data'] = {}
+    data = session['process_data']
+
+    if request.method == 'POST':
+        if step == 1:
+            data['email'] = request.form.get('email')
+        elif step == 2:
+            data['num_people'] = request.form.get('num_people')
+            data['move_in'] = request.form.get('move_in')
+            data['pets'] = request.form.get('pets')
+            data['job'] = request.form.get('job')
+            data['budget'] = request.form.get('budget')
+        elif step == 3:
+            data['appointment'] = request.form.get('appointment')
+        elif step == 4:
+            data['name'] = request.form.get('name')
+            data['phone'] = request.form.get('phone')
+            data['apartment'] = request.form.get('apartment')
+            save_application(
+                {
+                    'name': data['name'],
+                    'email': data.get('email', ''),
+                    'phone': data['phone'],
+                    'apartment': data['apartment'],
+                }
+            )
+        session['process_data'] = data
+        next_step = step + 1
+        return redirect(url_for('process', step=next_step))
+
+    if step > 10:
+        step = 10
+    return render_template('process.html', step=step, data=data)
 
 if __name__ == '__main__':
     init_db()

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,5 +6,6 @@
 <body>
     <h1>Welcome to our Apartment Leasing Portal</h1>
     <p><a href="{{ url_for('apply') }}">Apply for an apartment</a></p>
+    <p><a href="{{ url_for('process') }}">Start leasing process</a></p>
 </body>
 </html>

--- a/templates/process.html
+++ b/templates/process.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leasing Process</title>
+</head>
+<body>
+    <h1>Apartment Leasing Process</h1>
+    {% if step == 1 %}
+        <h2>Step 1: Respond to an apartment ad via email</h2>
+        <form method="post">
+            <label>Your Email: <input type="email" name="email" required></label><br>
+            <button type="submit">Next</button>
+        </form>
+    {% elif step == 2 %}
+        <h2>Step 2: Basic Questions</h2>
+        <form method="post">
+            <label>Number of Occupants: <input type="number" name="num_people" required></label><br>
+            <label>Move-in Date: <input type="date" name="move_in" required></label><br>
+            <label>Pets: <input type="text" name="pets"></label><br>
+            <label>Job: <input type="text" name="job"></label><br>
+            <label>Budget: <input type="text" name="budget"></label><br>
+            <button type="submit">Next</button>
+        </form>
+    {% elif step == 3 %}
+        <h2>Step 3: Set up appointment to see the apartment</h2>
+        <form method="post">
+            <label>Preferred Appointment Date/Time: <input type="text" name="appointment" required></label><br>
+            <button type="submit">Next</button>
+        </form>
+    {% elif step == 4 %}
+        <h2>Step 4: Fill out application</h2>
+        <form method="post">
+            <label>Name: <input type="text" name="name" required></label><br>
+            <label>Phone: <input type="text" name="phone" required></label><br>
+            <label>Apartment Interested In: <input type="text" name="apartment" required></label><br>
+            <button type="submit">Submit Application</button>
+        </form>
+    {% elif step == 5 %}
+        <h2>Step 5: Application approved - review lease</h2>
+        <form method="post">
+            <button type="submit">I have reviewed the lease</button>
+        </form>
+    {% elif step == 6 %}
+        <h2>Step 6: Sign lease and pay deposit and first month rent</h2>
+        <form method="post">
+            <button type="submit">I have signed and funded</button>
+        </form>
+    {% elif step == 7 %}
+        <h2>Step 7: Receive signed lease from apartment owner</h2>
+        <form method="post">
+            <button type="submit">Confirm Receipt</button>
+        </form>
+    {% elif step == 8 %}
+        <h2>Step 8: Set up electric and gas service</h2>
+        <form method="post">
+            <button type="submit">Service Arranged</button>
+        </form>
+    {% elif step == 9 %}
+        <h2>Step 9: Complete change of address form at postal service</h2>
+        <form method="post">
+            <button type="submit">Address Updated</button>
+        </form>
+    {% else %}
+        <h2>Step 10: Move in to the apartment</h2>
+        <p>Congratulations! You're ready to move in.</p>
+    {% endif %}
+    <p><a href="{{ url_for('index') }}">Back to home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/process` route that guides users through 10 leasing steps
- store progress in session and save application data
- link new process from homepage
- document new workflow in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687ef2f5896c8329bd604a86e49410a4